### PR TITLE
Add moderation commands

### DIFF
--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -921,6 +921,9 @@ moderation.warning = WARNING
 
 moderation.mute.message = You have been muted and are unable to send chat messages.
 
+# {0} = Name of muted player
+moderation.mute.existing = {0} is already muted!
+
 moderation.type.kick = Kick
 moderation.type.mute = Mute
 moderation.type.warn = Warn

--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -898,3 +898,38 @@ observer.tools.visibility.hidden = Hidden
 # {1} = List of staff players
 moderation.staff.name = Online Staff ({0}): {1}
 moderation.staff.empty = No staff online :(
+
+# {0} = Name of punishment type
+moderation.punishment.prefix = [{0}]
+
+# {0} = Reason for punishment
+moderation.screen.kick = You were kicked for {0}
+moderation.screen.ban = You were banned for {0}
+
+# {0} = Formatted date of expiry
+moderation.screen.banExpire = Expires on {0}
+
+moderation.screen.rulesLink = Please review our rules at {0}
+
+# {0} = Name of staff member 
+moderation.screen.signoff = Issued by {0}
+
+# {0} = Time until the ban expires
+moderation.screen.expires = Expires in {0}
+
+moderation.warning = WARNING
+
+moderation.mute.message = You have been muted and are unable to send chat messages.
+
+moderation.type.kick = Kick
+moderation.type.mute = Mute
+moderation.type.warn = Warn
+moderation.type.ban = Ban
+moderation.type.temp_ban = Temp-Ban
+
+# {0} = Name of unmuted target
+moderation.unmute.sender = You have unmuted {0}
+moderation.unmute.target = You have been unmuted and may now send messages
+
+# {0} = Name of target
+moderation.unmute.none = {0} is not muted.

--- a/src/main/i18n/templates/strings.properties
+++ b/src/main/i18n/templates/strings.properties
@@ -905,6 +905,7 @@ moderation.punishment.prefix = [{0}]
 # {0} = Reason for punishment
 moderation.screen.kick = You were kicked for {0}
 moderation.screen.ban = You were banned for {0}
+moderation.screen.temp_ban = You were temporarily banned for {0}
 
 # {0} = Formatted date of expiry
 moderation.screen.banExpire = Expires on {0}

--- a/src/main/java/tc/oc/pgm/Config.java
+++ b/src/main/java/tc/oc/pgm/Config.java
@@ -488,4 +488,20 @@ public class Config {
       return getConfiguration().getBoolean("sidebar.overwrite", false);
     }
   }
+
+  public static class Moderation {
+
+    public static boolean isRuleLinkVisible() {
+      return getRulesLink().length() > 0;
+    }
+
+    public static String getRulesLink() {
+      return getConfiguration().getString("moderation.rules-link", "");
+    }
+
+    public static String getServerName() {
+      return ChatColor.translateAlternateColorCodes(
+          '&', getConfiguration().getString("moderation.server-name", ""));
+    }
+  }
 }

--- a/src/main/java/tc/oc/pgm/PGMImpl.java
+++ b/src/main/java/tc/oc/pgm/PGMImpl.java
@@ -370,7 +370,7 @@ public final class PGMImpl extends JavaPlugin implements PGM, IdentityProvider, 
     node.registerNode("mode", "modes").registerCommands(new ModeCommands());
     node.registerCommands(new TimeLimitCommands());
     node.registerCommands(new SettingCommands());
-    node.registerCommands(new ModerationCommands());
+    node.registerCommands(new ModerationCommands(chat));
     node.registerCommands(new ObserverCommands());
     node.registerCommands(new MapPoolCommands());
 

--- a/src/main/java/tc/oc/pgm/api/Permissions.java
+++ b/src/main/java/tc/oc/pgm/api/Permissions.java
@@ -31,6 +31,13 @@ public interface Permissions {
   String STAFF = ROOT + ".staff"; // Considered apart of the staff team
   String RELOAD = ROOT + ".reload"; // Reload the PGM configuration
 
+  // Individual permissions related to moderation
+  String MODERATION = ROOT + ".moderation"; // General node for moderation
+  String KICK = MODERATION + ".kick"; // Access to the /kick command
+  String WARN = MODERATION + ".warn"; // Access to the /warn command
+  String MUTE = MODERATION + ".mute"; // Access to the /mute command
+  String BAN = MODERATION + ".ban"; // Access to the /ban command
+
   // Role-specific permission nodes
   Permission DEFAULT =
       new Permission(

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -2,16 +2,21 @@ package tc.oc.pgm.commands;
 
 import app.ashcon.intake.Command;
 import app.ashcon.intake.CommandException;
+import app.ashcon.intake.parametric.annotation.Switch;
 import app.ashcon.intake.parametric.annotation.Text;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.Lists;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import net.md_5.bungee.api.ChatColor;
+import org.bukkit.BanList;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -19,6 +24,7 @@ import tc.oc.component.Component;
 import tc.oc.component.types.PersonalizedText;
 import tc.oc.component.types.PersonalizedTranslatable;
 import tc.oc.named.NameStyle;
+import tc.oc.pgm.Config;
 import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.chat.Audience;
 import tc.oc.pgm.api.chat.Sound;
@@ -26,23 +32,46 @@ import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
+import tc.oc.pgm.events.PlayerPunishmentEvent;
 import tc.oc.pgm.events.PlayerReportEvent;
+import tc.oc.pgm.events.PlayerTimedPunishmentEvent;
+import tc.oc.pgm.listeners.ChatDispatcher;
+import tc.oc.util.components.ComponentUtils;
 import tc.oc.util.components.Components;
+import tc.oc.util.components.PeriodFormats;
 
 public class ModerationCommands {
 
+  private static final Sound WARN_SOUND = new Sound("mob.enderdragon.growl", 1f, 1f);
+  private static final Component WARN_SYMBOL =
+      new PersonalizedText(" \u26a0 ").color(ChatColor.YELLOW);
+  private static final Component BROADCAST_DIV =
+      new PersonalizedText(" \u00BB ").color(ChatColor.GOLD);
+
+  private static final Component CONSOLE_NAME =
+      new PersonalizedTranslatable("console")
+          .getPersonalizedText()
+          .color(ChatColor.YELLOW)
+          .italic(true);
+
   private static final int REPORT_COOLDOWN_SECONDS = 15;
 
-  private static final Cache<UUID, Instant> LAST_REPORT_SENT =
+  private final Cache<UUID, Instant> LAST_REPORT_SENT =
       CacheBuilder.newBuilder().expireAfterWrite(REPORT_COOLDOWN_SECONDS, TimeUnit.SECONDS).build();
 
   private static final Sound REPORT_NOTIFY_SOUND = new Sound("random.pop", 1f, 1.2f);
+
+  private final ChatDispatcher chat;
+
+  public ModerationCommands(ChatDispatcher chat) {
+    this.chat = chat;
+  }
 
   @Command(
       aliases = {"report"},
       usage = "<player> <reason>",
       desc = "Report a player who is breaking the rules")
-  public static void report(
+  public void report(
       CommandSender commandSender,
       MatchPlayer matchPlayer,
       Match match,
@@ -155,5 +184,412 @@ public class ModerationCommands {
 
     // Send message
     sender.sendMessage(staff);
+  }
+
+  @Command(
+      aliases = {"mute", "m"},
+      usage = "<player> <reason> -s (silent) -w (warn)",
+      desc = "Mute a player",
+      perms = Permissions.MUTE)
+  public void mute(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent,
+      @Switch('w') boolean warn) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+
+    // if -w, also warn the player but don't broadcast warning
+    if (warn) {
+      warn(sender, target, match, reason, true);
+    }
+
+    // Create event and call it
+    PlayerPunishmentEvent event =
+        punish(PunishmentType.MUTE, targetMatchPlayer, sender, reason, silent);
+
+    // Check if cancelled, otherwise perform default actions
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        sender.sendMessage(event.getCancelMessage());
+      }
+      return;
+    } else {
+      broadcastPunishment(event);
+    }
+  }
+
+  @Command(
+      aliases = {"unmute", "um"},
+      usage = "<player>",
+      desc = "Unmute a player",
+      perms = Permissions.MUTE)
+  public void unMute(CommandSender sender, Player target, Match match) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+    if (chat.isMuted(targetMatchPlayer)) {
+      // Remove the mute
+      chat.removeMuted(targetMatchPlayer);
+
+      // Send feedback to target and sender
+      targetMatchPlayer.sendMessage(
+          new PersonalizedTranslatable("moderation.unmute.target")
+              .getPersonalizedText()
+              .color(ChatColor.GREEN));
+      sender.sendMessage(
+          new PersonalizedTranslatable(
+                  "moderation.unmute.sender", targetMatchPlayer.getStyledName(NameStyle.FANCY))
+              .color(ChatColor.GRAY));
+    } else {
+      sender.sendMessage(
+          new PersonalizedTranslatable(
+                  "moderation.unmute.none", targetMatchPlayer.getStyledName(NameStyle.FANCY))
+              .getPersonalizedText()
+              .color(ChatColor.RED));
+    }
+  }
+
+  @Command(
+      aliases = {"warn", "w"},
+      usage = "<player> <reason> -s (silent)",
+      desc = "Warn a player for bad behavior",
+      perms = Permissions.WARN)
+  public void warn(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+
+    // Create event and call it
+    PlayerPunishmentEvent event =
+        punish(PunishmentType.WARN, targetMatchPlayer, sender, reason, silent);
+
+    // Check if cancelled, otherwise perform default actions
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        sender.sendMessage(event.getCancelMessage());
+      }
+      return;
+    } else {
+      // Broadcast the punishment
+      broadcastPunishment(event);
+
+      // Send warning message to the target
+      sendWarning(targetMatchPlayer, reason);
+    }
+  }
+
+  @Command(
+      aliases = {"kick", "k"},
+      usage = "<player> <reason> -s (silent)",
+      desc = "Kick a player from the server",
+      perms = Permissions.KICK)
+  public void kick(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+
+    // Create event and call it
+    PlayerPunishmentEvent event =
+        punish(PunishmentType.KICK, targetMatchPlayer, sender, reason, silent);
+
+    // Check if cancelled, otherwise perform default actions
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        sender.sendMessage(event.getCancelMessage());
+      }
+      return;
+    } else {
+      // Broadcast the punishment
+      broadcastPunishment(event);
+
+      // Kick the player
+      target.kickPlayer(
+          formatPunishmentScreen(
+              PunishmentType.KICK, formatPunisherName(sender, match), reason, null));
+    }
+  }
+
+  @Command(
+      aliases = {"ban", "permban", "pb"},
+      usage = "<player> <reason> -s (silent)",
+      desc = "Ban a player from the server forever",
+      perms = Permissions.BAN)
+  public void ban(
+      CommandSender sender,
+      Player target,
+      Match match,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+
+    // Create event and call it
+    PlayerPunishmentEvent event =
+        punish(PunishmentType.BAN, targetMatchPlayer, sender, reason, silent);
+
+    // Check if cancelled, otherwise perform default actions
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        sender.sendMessage(event.getCancelMessage());
+      }
+      return;
+    } else {
+      // Broadcast punishment
+      broadcastPunishment(event);
+
+      // Ban the Player
+      banPlayer(event, null);
+
+      // Kick the now banned player
+      target.kickPlayer(
+          formatPunishmentScreen(
+              PunishmentType.BAN, formatPunisherName(sender, match), reason, null));
+    }
+  }
+
+  @Command(
+      aliases = {"tempban", "tban", "tb"},
+      usage = "<player> <time> <reason> -s (silent)",
+      desc = "Ban a player from the server for a period of time",
+      perms = Permissions.BAN)
+  public void tempBan(
+      CommandSender sender,
+      Player target,
+      Match match,
+      Duration banLength,
+      @Text String reason,
+      @Switch('s') boolean silent) {
+    MatchPlayer targetMatchPlayer = match.getPlayer(target);
+
+    // Special event called for TEMP ban
+    PlayerTimedPunishmentEvent event =
+        new PlayerTimedPunishmentEvent(
+            sender, targetMatchPlayer, PunishmentType.TEMP_BAN, reason, silent, banLength);
+    match.callEvent(event);
+
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        sender.sendMessage(event.getCancelMessage());
+      }
+      return;
+    } else {
+      // Broadcast punishment
+      broadcastPunishment(event);
+
+      // Ban the player
+      banPlayer(event, event.getExpiryDate());
+
+      // Kick the now banned player
+      target.kickPlayer(
+          formatPunishmentScreen(
+              PunishmentType.BAN, formatPunisherName(sender, match), reason, banLength));
+    }
+  }
+
+  private PlayerPunishmentEvent punish(
+      PunishmentType type,
+      MatchPlayer target,
+      CommandSender issuer,
+      String reason,
+      boolean silent) {
+    PlayerPunishmentEvent event = new PlayerPunishmentEvent(issuer, target, type, reason, silent);
+    target.getMatch().callEvent(event);
+
+    return event;
+  }
+
+  public static enum PunishmentType {
+    MUTE(false),
+    WARN(false),
+    KICK(true),
+    BAN(true),
+    TEMP_BAN(true);
+
+    private String PREFIX_TRANSLATE_KEY = "moderation.type.";
+    private String SCREEN_TRANSLATE_KEY = "moderation.screen.";
+
+    private final boolean screen;
+
+    PunishmentType(boolean screen) {
+      this.screen = screen;
+    }
+
+    public Component getPunishmentPrefix() {
+      return new PersonalizedTranslatable(PREFIX_TRANSLATE_KEY + name().toLowerCase())
+          .getPersonalizedText()
+          .color(ChatColor.RED);
+    }
+
+    public Component getScreenComponent(Component reason) {
+      if (screen) {
+        return new PersonalizedTranslatable(SCREEN_TRANSLATE_KEY + name().toLowerCase(), reason)
+            .getPersonalizedText()
+            .color(ChatColor.GOLD);
+      } else {
+        return Components.blank();
+      }
+    }
+  }
+
+  /*
+   * Format Punisher Name
+   */
+  public static Component formatPunisherName(CommandSender sender, Match match) {
+    Component name = CONSOLE_NAME;
+    if (sender instanceof Player) {
+      Player senderBukkit = (Player) sender;
+      if (senderBukkit != null) {
+        MatchPlayer senderMatchPlayer = match.getPlayer(senderBukkit);
+        if (senderMatchPlayer != null) {
+          name = senderMatchPlayer.getStyledName(NameStyle.FANCY);
+        }
+      }
+    }
+    return name;
+  }
+
+  /*
+   * Format Reason
+   */
+  public static Component formatPunishmentReason(String reason) {
+    return new PersonalizedText(reason).color(ChatColor.RED);
+  }
+
+  /*
+   * Formatting of Kick Screens (KICK/BAN/TEMPBAN)
+   */
+  public static String formatPunishmentScreen(
+      PunishmentType type, Component punisher, String reason, @Nullable Duration expires) {
+    List<Component> lines = Lists.newArrayList();
+
+    Component header =
+        new PersonalizedText(
+            ComponentUtils.horizontalLineHeading(
+                Config.Moderation.getServerName(), ChatColor.DARK_GRAY));
+
+    Component footer =
+        new PersonalizedText(
+            ComponentUtils.horizontalLine(ChatColor.DARK_GRAY, ComponentUtils.MAX_CHAT_WIDTH));
+
+    Component rules = new PersonalizedText(Config.Moderation.getRulesLink()).color(ChatColor.AQUA);
+
+    lines.add(header); // Header Line (server name) - START
+    lines.add(Components.blank());
+    lines.add(type.getScreenComponent(formatPunishmentReason(reason))); // The reason
+    lines.add(Components.blank());
+
+    // If punishment expires, inform user when
+    if (expires != null) {
+      Component timeLeft =
+          PeriodFormats.briefNaturalApproximate(
+              org.joda.time.Duration.standardSeconds(expires.getSeconds()));
+      lines.add(
+          new PersonalizedTranslatable("moderation.screen.expires", timeLeft)
+              .getPersonalizedText()
+              .color(ChatColor.GRAY));
+      lines.add(Components.blank());
+    }
+
+    // Staff sign-off
+    lines.add(
+        new PersonalizedTranslatable("moderation.screen.signoff", punisher)
+            .getPersonalizedText()
+            .color(ChatColor.GRAY)); // The sign-off of who performed the punishment
+    lines.add(Components.blank());
+
+    // Link to rules for review by player
+    if (Config.Moderation.isRuleLinkVisible()) {
+      lines.add(
+          new PersonalizedTranslatable("moderation.screen.rulesLink", rules)
+              .getPersonalizedText()
+              .color(ChatColor.GRAY)); // A link to the rules
+    }
+    lines.add(Components.blank());
+
+    lines.add(footer); // Footer line - END
+
+    return Components.join(new PersonalizedText("\n" + ChatColor.RESET), lines).toLegacyText();
+  }
+
+  /*
+   * Sends a formatted title and plays a sound warning a user of their actions
+   */
+  private void sendWarning(MatchPlayer target, String reason) {
+    showWarningTitle(target, reason);
+    target.playSound(WARN_SOUND);
+  }
+
+  private void showWarningTitle(MatchPlayer target, String reason) {
+    Component titleWord =
+        new PersonalizedTranslatable("moderation.warning")
+            .getPersonalizedText()
+            .color(ChatColor.DARK_RED);
+    Component title = new PersonalizedText(WARN_SYMBOL, titleWord, WARN_SYMBOL);
+    Component subtitle = formatPunishmentReason(reason).color(ChatColor.GOLD);
+
+    target.showTitle(title, subtitle, 5, 200, 10);
+  }
+
+  private void broadcastPunishment(PlayerPunishmentEvent event) {
+    broadcastPunishment(
+        event.getType(),
+        event.getPlayer().getMatch(),
+        event.getSender(),
+        event.getPlayer(),
+        event.getReason(),
+        event.isSilent());
+  }
+
+  /*
+   * Broadcasts a punishment
+   */
+  private void broadcastPunishment(
+      PunishmentType type,
+      Match match,
+      CommandSender sender,
+      MatchPlayer target,
+      String reason,
+      boolean silent) {
+    Component prefix =
+        new PersonalizedTranslatable("moderation.punishment.prefix", type.getPunishmentPrefix())
+            .getPersonalizedText()
+            .color(ChatColor.GOLD);
+    Component targetName = target.getStyledName(NameStyle.FANCY);
+    Component reasonMsg = ModerationCommands.formatPunishmentReason(reason);
+    Component formattedMsg =
+        new PersonalizedText(
+            prefix,
+            Components.space(),
+            ModerationCommands.formatPunisherName(sender, match),
+            BROADCAST_DIV,
+            targetName,
+            BROADCAST_DIV,
+            reasonMsg);
+
+    if (!silent) {
+      match.sendMessage(formattedMsg);
+    } else {
+      // if silent flag present, only notify sender
+      sender.sendMessage(formattedMsg);
+    }
+  }
+
+  /*
+   * Bukkit method of banning players
+   * NOTE: Will use this if not handled by other plugins
+   */
+  private void banPlayer(PlayerPunishmentEvent event, @Nullable Instant expires) {
+    Bukkit.getBanList(BanList.Type.NAME)
+        .addBan(
+            event.getPlayer().getBukkit().getName(),
+            event.getReason(),
+            expires != null ? Date.from(expires) : null,
+            event.getSender().getName());
   }
 }

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -326,7 +326,7 @@ public class ModerationCommands {
       banPlayer(target, reason, formatPunisherName(sender, match), event.getExpiryDate());
       target.kickPlayer(
           formatPunishmentScreen(
-              PunishmentType.BAN, formatPunisherName(sender, match), reason, banLength));
+              PunishmentType.TEMP_BAN, formatPunisherName(sender, match), reason, banLength));
     } else if (event.getCancelMessage() != null) {
       sender.sendMessage(event.getCancelMessage());
     }

--- a/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/ModerationCommands.java
@@ -201,21 +201,22 @@ public class ModerationCommands {
       @Switch('w') boolean warn) {
     MatchPlayer targetMatchPlayer = match.getPlayer(target);
 
+    if (chat.isMuted(targetMatchPlayer)) {
+      sender.sendMessage(
+          new PersonalizedTranslatable(
+                  "moderation.mute.existing", targetMatchPlayer.getStyledName(NameStyle.FANCY))
+              .getPersonalizedText()
+              .color(ChatColor.RED));
+      return;
+    }
+
     // if -w flag, also warn the player but don't broadcast warning
     if (warn) {
       warn(sender, target, match, reason, true);
     }
 
     if (punish(PunishmentType.MUTE, targetMatchPlayer, sender, reason, silent)) {
-      if (chat.isMuted(targetMatchPlayer)) {
-        sender.sendMessage(
-            new PersonalizedTranslatable(
-                    "moderation.mute.existing", targetMatchPlayer.getStyledName(NameStyle.FANCY))
-                .getPersonalizedText()
-                .color(ChatColor.RED));
-      } else {
-        chat.addMuted(targetMatchPlayer);
-      }
+      chat.addMuted(targetMatchPlayer);
     }
   }
 
@@ -339,8 +340,10 @@ public class ModerationCommands {
       boolean silent) {
     PlayerPunishmentEvent event = new PlayerPunishmentEvent(issuer, target, type, reason, silent);
     target.getMatch().callEvent(event);
-    if (event.isCancelled() && event.getCancelMessage() != null) {
-      issuer.sendMessage(event.getCancelMessage());
+    if (event.isCancelled()) {
+      if (event.getCancelMessage() != null) {
+        issuer.sendMessage(event.getCancelMessage());
+      }
     } else if (!silent) {
       broadcastPunishment(event);
     }

--- a/src/main/java/tc/oc/pgm/events/PlayerPunishmentEvent.java
+++ b/src/main/java/tc/oc/pgm/events/PlayerPunishmentEvent.java
@@ -1,0 +1,63 @@
+package tc.oc.pgm.events;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import tc.oc.pgm.api.event.ExtendedCancellable;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.commands.ModerationCommands.PunishmentType;
+
+/** Called when a punishment command is run * */
+public class PlayerPunishmentEvent extends ExtendedCancellable {
+
+  private final CommandSender sender;
+  private final MatchPlayer player;
+  private final PunishmentType punishment;
+  private final String reason;
+  private final boolean silent;
+
+  public PlayerPunishmentEvent(
+      CommandSender sender,
+      MatchPlayer player,
+      PunishmentType punishment,
+      String reason,
+      boolean silent) {
+    this.sender = checkNotNull(sender);
+    this.player = checkNotNull(player);
+    this.punishment = checkNotNull(punishment);
+    this.reason = checkNotNull(reason);
+    this.silent = checkNotNull(silent);
+  }
+
+  public CommandSender getSender() {
+    return sender;
+  }
+
+  public PunishmentType getType() {
+    return punishment;
+  }
+
+  public MatchPlayer getPlayer() {
+    return player;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public boolean isSilent() {
+    return silent;
+  }
+
+  private static final HandlerList handlers = new HandlerList();
+
+  @Override
+  public HandlerList getHandlers() {
+    return handlers;
+  }
+
+  public static HandlerList getHandlerList() {
+    return handlers;
+  }
+}

--- a/src/main/java/tc/oc/pgm/events/PlayerTimedPunishmentEvent.java
+++ b/src/main/java/tc/oc/pgm/events/PlayerTimedPunishmentEvent.java
@@ -1,0 +1,34 @@
+package tc.oc.pgm.events;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.commands.ModerationCommands.PunishmentType;
+
+/** Called when a punishment that expires after a duration of time is created * */
+public class PlayerTimedPunishmentEvent extends PlayerPunishmentEvent {
+
+  private final Duration time;
+
+  public PlayerTimedPunishmentEvent(
+      CommandSender sender,
+      MatchPlayer player,
+      PunishmentType punishment,
+      String reason,
+      boolean silent,
+      Duration expires) {
+    super(sender, player, punishment, reason, silent);
+    this.time = checkNotNull(expires);
+  }
+
+  public Duration getPunishmentLength() {
+    return time;
+  }
+
+  public Instant getExpiryDate() {
+    return Instant.now().plus(time);
+  }
+}

--- a/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
+++ b/src/main/java/tc/oc/pgm/listeners/ChatDispatcher.java
@@ -32,9 +32,7 @@ import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.api.setting.SettingKey;
 import tc.oc.pgm.api.setting.SettingValue;
-import tc.oc.pgm.commands.ModerationCommands.PunishmentType;
 import tc.oc.pgm.commands.SettingCommands;
-import tc.oc.pgm.events.PlayerPunishmentEvent;
 import tc.oc.pgm.ffa.Tribute;
 import tc.oc.util.StringUtils;
 import tc.oc.util.components.Components;
@@ -238,20 +236,6 @@ public class ChatDispatcher implements Listener {
         sendAdmin(player.getMatch(), player, event.getMessage().substring(1));
       } else {
         sendDefault(player.getMatch(), player, event.getMessage());
-      }
-    }
-  }
-
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-  public void onMutePlayer(PlayerPunishmentEvent event) {
-    if (event.getType().equals(PunishmentType.MUTE)) {
-      if (isMuted(event.getPlayer())) {
-        Component errorMsg =
-            new PersonalizedTranslatable(
-                    "moderation.mute.existing", event.getPlayer().getStyledName(NameStyle.FANCY))
-                .getPersonalizedText()
-                .color(ChatColor.RED);
-        event.setCancelled(true, errorMsg);
       }
     }
   }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -109,3 +109,11 @@ sidebar:
   bottom: ""
   # If the sidebar message should overwrite lines in the sidebar when it is full
   overwrite: false
+  
+moderation:
+  # Link to a rules website to display on kick screen
+  rules-link: ''
+  
+  # Name of server to display on kick screen header
+  # Name may be formatted with '&' color codes
+  server-name: ''


### PR DESCRIPTION
# Add moderation commands 🎉 
This is a revamped version of my [PR](https://github.com/Electroid/PGM/pull/300). I did make all the suggested changes by @Pablete1234. Mostly removing the moderation listener and fixing issues with joda time. 

For command formatting screenshots please see the linked PR above.

## Bans

Currently in this version bans will be saved to bukkit’s `banned-players.json` file using the methods provided by bukkit. 

There is one drawback to how this is currently implemented, and that is the default “bukkit/vanilla” ban screens when logging in are not formatted the same way as when they are kicked here.

Example:
What is shown when a player is banned and kicked from the server.
![full-ban-pre](https://user-images.githubusercontent.com/3377659/74577487-43acf400-4f44-11ea-83bc-f56d562297b3.png)

What is shown (by bukkit) when a player who is banned tries to log back in LATER.
![full-ban-after](https://user-images.githubusercontent.com/3377659/74577493-47d91180-4f44-11ea-8d26-2d195890f478.png)

What is shown when a user is temp-banned and kicked from the server.
![temp-pre](https://user-images.githubusercontent.com/3377659/74577502-4c052f00-4f44-11ea-872e-88e7b2a9478e.png)

What is shown when a player is temp-banned and attempts a login to the server LATER.
![temp-after](https://user-images.githubusercontent.com/3377659/74577504-4e678900-4f44-11ea-989d-8dce5061e434.png)


I am currently working on a [PGModeration](https://github.com/applenick/PGModeration) plugin which could complement the moderation commands in this PR. Implementing things such as:
- Formatting the login screen for banned/temp-banned players (fixes the problem above)
- Saving a list of recent (since server start) /reports, so a mod can log on and see if a player has multiple reports

Though I am unsure if creating the additional plugin is necessary, since we can always just implement those features into PGM directly. Any thoughts on that?

## Converting from CommandBook bans to PGM moderation commands
In order to convert command book bans to the bukkit I’ve forked CommandBook at the version @Brottweiler told me OCC was using. Then added a simple `/bans convert -v (verbose)`, which will convert the command book bans database to the bukkit method.

From my testing I found no issues, however I would perhaps not perform the actual conversion on a production server. Since when I performed the conversion it was only with a few ban entries. I’m unsure how many OCC has, but perhaps a local conversion could be done prior, then just transfer the new `banned-players.json` file to the main server.

Link to my version of [commandbook](https://github.com/applenick/CommandBook), make sure to use the `PGM-OCC` branch. 

Signed-off-by: applenick <applenick@users.noreply.github.com>