### PR TITLE
Refactor map polls into map vote pickers

### DIFF
--- a/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingKey.java
@@ -31,6 +31,7 @@ public enum SettingKey {
     }
   }, // Changes if observers are visible
   SOUNDS("sounds", SOUNDS_ON, SOUNDS_OFF), // Changes if sounds are played
+  VOTE("vote", VOTE_ON, VOTE_OFF), // Changes if the voting book is shown
   ;
 
   private final List<String> aliases;

--- a/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
+++ b/src/main/java/tc/oc/pgm/api/setting/SettingValue.java
@@ -36,6 +36,9 @@ public enum SettingValue {
 
   SOUNDS_ON("sounds", "on"), // Always play sounds
   SOUNDS_OFF("sounds", "off"), // Never play sounds
+
+  VOTE_ON("vote", "on"), // Show voting book
+  VOTE_OFF("vote", "off"), // Don't show voting book
   ;
 
   private final String key;

--- a/src/main/java/tc/oc/pgm/commands/MapPoolCommands.java
+++ b/src/main/java/tc/oc/pgm/commands/MapPoolCommands.java
@@ -21,11 +21,11 @@ import tc.oc.pgm.api.chat.Audience;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.rotation.MapOrder;
-import tc.oc.pgm.rotation.MapPoll;
-import tc.oc.pgm.rotation.MapPool;
 import tc.oc.pgm.rotation.MapPoolManager;
-import tc.oc.pgm.rotation.Rotation;
-import tc.oc.pgm.rotation.VotingPool;
+import tc.oc.pgm.rotation.pools.MapPool;
+import tc.oc.pgm.rotation.pools.Rotation;
+import tc.oc.pgm.rotation.pools.VotingPool;
+import tc.oc.pgm.rotation.vote.MapPoll;
 import tc.oc.pgm.util.PrettyPaginatedResult;
 import tc.oc.util.components.ComponentUtils;
 
@@ -77,7 +77,7 @@ public class MapPoolCommands {
     if (chance && votes != null) {
       double maxWeight = 0, currWeight;
       for (MapInfo map : votes.getMaps()) {
-        chances.put(map, currWeight = MapPoll.getWeight(votes.getMapScore(map)));
+        chances.put(map, currWeight = VotingPool.MAP_PICKER.weigh(map, votes.getMapScore(map)));
         maxWeight += currWeight;
       }
       double finalMaxWeight = maxWeight;

--- a/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
+++ b/src/main/java/tc/oc/pgm/rotation/MapPoolManager.java
@@ -16,6 +16,7 @@ import tc.oc.pgm.AllTranslations;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.rotation.pools.MapPool;
 
 /**
  * Manages all the existing {@link MapPool}s, as for maintaining their order, and updating the one
@@ -113,7 +114,7 @@ public class MapPoolManager implements MapOrder {
         .orElse(null);
   }
 
-  protected MapInfo getOverriderMap() {
+  public MapInfo getOverriderMap() {
     return overriderMap;
   }
 

--- a/src/main/java/tc/oc/pgm/rotation/pools/DisabledMapPool.java
+++ b/src/main/java/tc/oc/pgm/rotation/pools/DisabledMapPool.java
@@ -1,7 +1,8 @@
-package tc.oc.pgm.rotation;
+package tc.oc.pgm.rotation.pools;
 
 import org.bukkit.configuration.ConfigurationSection;
 import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.rotation.MapPoolManager;
 
 public class DisabledMapPool extends MapPool {
   DisabledMapPool(MapPoolManager manager, ConfigurationSection section, String name) {

--- a/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
+++ b/src/main/java/tc/oc/pgm/rotation/pools/MapPool.java
@@ -1,4 +1,4 @@
-package tc.oc.pgm.rotation;
+package tc.oc.pgm.rotation.pools;
 
 import java.util.Collections;
 import java.util.List;
@@ -11,6 +11,8 @@ import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapLibrary;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.rotation.MapOrder;
+import tc.oc.pgm.rotation.MapPoolManager;
 
 /** Rotation of maps, a type of {@link MapOrder} */
 public abstract class MapPool implements MapOrder, Comparable<MapPool> {

--- a/src/main/java/tc/oc/pgm/rotation/pools/Rotation.java
+++ b/src/main/java/tc/oc/pgm/rotation/pools/Rotation.java
@@ -1,10 +1,11 @@
-package tc.oc.pgm.rotation;
+package tc.oc.pgm.rotation.pools;
 
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import org.bukkit.configuration.ConfigurationSection;
 import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.map.MapInfo;
+import tc.oc.pgm.rotation.MapPoolManager;
 
 public class Rotation extends MapPool {
 

--- a/src/main/java/tc/oc/pgm/rotation/vote/DefaultMapVotePicker.java
+++ b/src/main/java/tc/oc/pgm/rotation/vote/DefaultMapVotePicker.java
@@ -1,0 +1,42 @@
+package tc.oc.pgm.rotation.vote;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import tc.oc.pgm.api.map.MapInfo;
+
+public class DefaultMapVotePicker implements MapVotePicker {
+
+  private static final int VOTE_OPTIONS = 5;
+
+  @Override
+  public List<MapInfo> pickMaps(Map<MapInfo, Double> mapScores) {
+
+    List<MapInfo> selectedMaps = new ArrayList<>();
+
+    mapScores = new HashMap<>(mapScores);
+
+    for (int i = 0; i < VOTE_OPTIONS; i++) {
+      NavigableMap<Double, MapInfo> cumulativeScores = new TreeMap<>();
+      double maxWeight = 0;
+      for (Map.Entry<MapInfo, Double> map : mapScores.entrySet()) {
+        cumulativeScores.put(maxWeight += weigh(map.getKey(), map.getValue()), map.getKey());
+      }
+      Map.Entry<Double, MapInfo> selectedMap =
+          cumulativeScores.higherEntry(Math.random() * maxWeight);
+
+      if (selectedMap == null) break; // No more maps to be picked
+      selectedMaps.add(selectedMap.getValue());
+      mapScores.remove(selectedMap.getValue());
+    }
+
+    return selectedMaps;
+  }
+
+  public Double weigh(MapInfo map, Double score) {
+    return score == null || score <= 0 ? 0 : Math.max(Math.pow(score, 2), Double.MIN_VALUE);
+  }
+}

--- a/src/main/java/tc/oc/pgm/rotation/vote/MapPoll.java
+++ b/src/main/java/tc/oc/pgm/rotation/vote/MapPoll.java
@@ -1,23 +1,18 @@
-package tc.oc.pgm.rotation;
+package tc.oc.pgm.rotation.vote;
 
 import app.ashcon.intake.CommandException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
@@ -26,11 +21,13 @@ import tc.oc.component.types.PersonalizedText;
 import tc.oc.component.types.PersonalizedTranslatable;
 import tc.oc.named.MapNameStyle;
 import tc.oc.pgm.AllTranslations;
-import tc.oc.pgm.api.Permissions;
 import tc.oc.pgm.api.map.MapInfo;
 import tc.oc.pgm.api.map.MapTag;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.api.setting.SettingKey;
+import tc.oc.pgm.api.setting.SettingValue;
+import tc.oc.util.collection.VoterSet;
 import tc.oc.util.components.Components;
 import tc.oc.world.NMSHacks;
 
@@ -42,67 +39,12 @@ public class MapPoll {
   private static final int TITLE_LENGTH_CUTOFF = 15;
 
   private final WeakReference<Match> match;
-  private final Map<MapInfo, Double> mapScores;
-  private final int voteSize;
 
-  private final Map<MapInfo, Set<UUID>> votes = new HashMap<>();
+  private final Map<MapInfo, VoterSet> votes = new LinkedHashMap<>();
 
-  MapPoll(Match match, Map<MapInfo, Double> mapScores, int voteSize) {
+  public MapPoll(Match match, List<MapInfo> maps) {
     this.match = new WeakReference<>(match);
-    this.mapScores = mapScores;
-    this.voteSize = voteSize;
-
-    selectMaps();
-  }
-
-  private void selectMaps() {
-    // Sorting beforehand, saves future key remaps, as bigger values are placed at the end
-    List<MapInfo> sortedDist =
-        mapScores.entrySet().stream()
-            .sorted(Comparator.comparingDouble(Map.Entry::getValue))
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
-
-    NavigableMap<Double, MapInfo> cumulativeScores = new TreeMap<>();
-    double maxWeight = cummulativeMap(0, sortedDist, cumulativeScores);
-
-    for (int i = 0; i < voteSize; i++) {
-      NavigableMap<Double, MapInfo> subMap =
-          cumulativeScores.tailMap(Math.random() * maxWeight, true);
-      Map.Entry<Double, MapInfo> selected = subMap.pollFirstEntry();
-
-      if (selected == null) break; // No more maps to poll
-      votes.put(selected.getValue(), new HashSet<>()); // Add map to votes
-      if (votes.size() >= voteSize) break; // Skip replace logic after all maps have been selected
-
-      // Remove map from pool, updating cumulative scores
-      double selectedWeight = getWeight(selected.getValue());
-      maxWeight -= selectedWeight;
-
-      NavigableMap<Double, MapInfo> temp = new TreeMap<>();
-      cummulativeMap(selected.getKey() - selectedWeight, subMap.values(), temp);
-
-      subMap.clear();
-      cumulativeScores.putAll(temp);
-    }
-  }
-
-  private double getWeight(MapInfo map) {
-    return getWeight(mapScores.get(map));
-  }
-
-  public static double getWeight(Double score) {
-    if (score == null || score <= 0) return 0;
-    return Math.max(Math.pow(score, 2), Double.MIN_VALUE);
-  }
-
-  private double cummulativeMap(
-      double currWeight, Collection<MapInfo> maps, Map<Double, MapInfo> result) {
-    for (MapInfo map : maps) {
-      double score = getWeight(map);
-      if (score > 0) result.put(currWeight += score, map);
-    }
-    return currWeight;
+    maps.forEach(m -> votes.put(m, new VoterSet()));
   }
 
   public void announceWinner(MatchPlayer viewer, MapInfo winner) {
@@ -124,7 +66,7 @@ public class MapPoll {
         new PersonalizedText(
             voted ? SYMBOL_VOTED : SYMBOL_IGNORE, voted ? ChatColor.GREEN : ChatColor.DARK_RED),
         new PersonalizedText(" ").bold(!voted), // Fix 1px symbol diff
-        new PersonalizedText("" + countVotes(votes.get(map)), ChatColor.YELLOW),
+        new PersonalizedText("" + votes.get(map).getVotes(), ChatColor.YELLOW),
         new PersonalizedText("] "),
         map.getStyledMapName(
             winner ? MapNameStyle.HIGHLIGHT_WITH_AUTHORS : MapNameStyle.COLOR_WITH_AUTHORS));
@@ -156,7 +98,8 @@ public class MapPoll {
       viewer.getInventory().setHeldItemSlot(2);
     }
     viewer.getInventory().setItemInHand(is);
-    NMSHacks.openBook(is, viewer.getBukkit());
+    if (viewer.getSettings().getValue(SettingKey.VOTE) == SettingValue.VOTE_ON)
+      NMSHacks.openBook(is, viewer.getBukkit());
   }
 
   private Component getMapBookComponent(MatchPlayer viewer, MapInfo map) {
@@ -185,7 +128,7 @@ public class MapPoll {
    * @throws CommandException If the map is not an option in the poll
    */
   public boolean toggleVote(MapInfo vote, UUID player) throws CommandException {
-    Set<UUID> votes = this.votes.get(vote);
+    VoterSet votes = this.votes.get(vote);
     if (votes == null) throw new CommandException(vote.getName() + " is not an option in the poll");
 
     if (votes.add(player)) return true;
@@ -196,24 +139,9 @@ public class MapPoll {
   /** @return The map currently winning the vote, null if no vote is running. */
   private MapInfo getMostVotedMap() {
     return votes.entrySet().stream()
-        .max(Comparator.comparingInt(e -> countVotes(e.getValue())))
+        .max(Comparator.comparingInt(e -> e.getValue().getVotes()))
         .map(Map.Entry::getKey)
         .orElse(null);
-  }
-
-  /**
-   * Count the amount of votes for a set of uuids. Players with the pgm.premium permission get
-   * double votes.
-   *
-   * @param uuids The players who voted
-   * @return The number of votes counted
-   */
-  private int countVotes(Set<UUID> uuids) {
-    return uuids.stream()
-        .map(Bukkit::getPlayer)
-        // Count disconnected players as 1, can't test for their perms
-        .mapToInt(p -> p == null || !p.hasPermission(Permissions.PREMIUM) ? 1 : 2)
-        .sum();
   }
 
   /**
@@ -221,20 +149,17 @@ public class MapPoll {
    *
    * @return The picked map to play after the vote
    */
-  MapInfo finishVote() {
+  public MapInfo finishVote() {
     MapInfo picked = getMostVotedMap();
     Match match = this.match.get();
     if (match != null) {
       match.getPlayers().forEach(player -> announceWinner(player, picked));
     }
 
-    updateScores();
     return picked;
   }
 
-  private void updateScores() {
-    double voters = votes.values().stream().flatMap(Collection::stream).distinct().count();
-    if (voters == 0) return;
-    votes.forEach((m, v) -> mapScores.put(m, Math.max(v.size() / voters, Double.MIN_VALUE)));
+  public Map<MapInfo, VoterSet> getVotes() {
+    return votes;
   }
 }

--- a/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
+++ b/src/main/java/tc/oc/pgm/rotation/vote/MapVotePicker.java
@@ -1,0 +1,15 @@
+package tc.oc.pgm.rotation.vote;
+
+import java.util.List;
+import java.util.Map;
+import tc.oc.pgm.api.map.MapInfo;
+
+/**
+ * Responsible for picking the set of maps that will be on the vote. It's able to apply any
+ * arbitrary rule to how the maps are picked from the available ones.
+ */
+public interface MapVotePicker {
+  List<MapInfo> pickMaps(Map<MapInfo, Double> scores);
+
+  Double weigh(MapInfo map, Double score);
+}

--- a/src/main/java/tc/oc/util/collection/VoterSet.java
+++ b/src/main/java/tc/oc/util/collection/VoterSet.java
@@ -1,0 +1,51 @@
+package tc.oc.util.collection;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.bukkit.Bukkit;
+import tc.oc.pgm.api.Permissions;
+
+/** A collection that will cache total votes casted, premium votes counting double */
+public class VoterSet {
+
+  private Set<UUID> voters = new HashSet<>();
+  private Integer votes = null;
+
+  public boolean add(UUID uuid) {
+    boolean modified = voters.add(uuid);
+    if (modified) votes = null;
+    return modified;
+  }
+
+  public void remove(UUID uuid) {
+    voters.remove(uuid);
+    votes = null;
+  }
+
+  public boolean contains(UUID uuid) {
+    return voters.contains(uuid);
+  }
+
+  public int size() {
+    return voters.size();
+  }
+
+  public int getVotes() {
+    return votes != null ? votes : updateVotes();
+  }
+
+  public Stream<UUID> stream() {
+    return voters.stream();
+  }
+
+  private int updateVotes() {
+    return votes =
+        voters.stream()
+            .map(Bukkit::getPlayer)
+            // Count disconnected players as 1, can't test for their perms
+            .mapToInt(p -> p == null || !p.hasPermission(Permissions.PREMIUM) ? 1 : 2)
+            .sum();
+  }
+}


### PR DESCRIPTION
Moved a decent bit of code arround, most relevant things are:
 - Map poll does no longer have the code for selecting the maps that it will poll for
 - The VotingPool now has a MapVotePicker responsible for picking the maps
 -  Moved the pools and the vote classes into respective packages inside rotations
 - Added option to not show the vote book

Still WIP, would like to provide more than just the default map vote picker, and make the voting pool use the map vote picker defined in the config for it.
 